### PR TITLE
fix(auth): stabilize session refresh and 401 handling

### DIFF
--- a/lib/api/base-query.ts
+++ b/lib/api/base-query.ts
@@ -52,7 +52,7 @@ const rawBaseQuery = fetchBaseQuery({
 });
 
 /**
- * Shared baseQuery wrapper that emits global auth events for 401/403/429.
+ * Shared baseQuery wrapper that emits global auth events for 401/429.
  * AuthContext listens to this event for deterministic auth/session behavior.
  */
 export const baseQuery: BaseQueryFn<
@@ -62,10 +62,7 @@ export const baseQuery: BaseQueryFn<
 > = async (args, api, extraOptions) => {
   const result = await rawBaseQuery(args, api, extraOptions);
   const status = result.error?.status;
-  if (
-    typeof window !== "undefined" &&
-    (status === 401 || status === 403 || status === 429)
-  ) {
+  if (typeof window !== "undefined" && (status === 401 || status === 429)) {
     const detail: AuthApiErrorEventDetail = {
       status,
       url:


### PR DESCRIPTION
- Non-deterministic redirects were caused by session-rotation races after RBAC writes triggered auth refresh while other requests were still in flight. Those in-flight requests sometimes returned 401 using the just-revoked session, and the global auth handler cleared session state, causing redirects to login or dashboard. The behavior was amplified because 403 responses were also treated as logout signals, even though they represent authorization failures rather than expired authentication.
---
- The fix changed global auth handling to clear session only on 401, added single-flight queued refresh execution, and suppressed stale 401 auth-error events during controlled refresh windows. These changes prevent random auth teardown during user/role-management writes while preserving deterministic logout behavior when a real unauthorized session refresh occurs.